### PR TITLE
Override grpc-netty dependencies to remove CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
 
     <properties>
         <grpc.version>1.57.0</grpc.version>
+        <netty.version>4.1.98.Final</netty.version>
         <tcnative.version>2.0.51.Final</tcnative.version>
         <asm.version>8.0.1</asm.version>
 
@@ -460,6 +461,22 @@
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-netty</artifactId>
                 <version>${grpc.version}</version>
+            </dependency>
+            <!-- override transitive netty dependencies within grpc-netty -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http2</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler-proxy</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-unix-common</artifactId>
+                <version>${netty.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Overrides the netty dependencies within [grpc-netty.](https://mvnrepository.com/artifact/io.grpc/grpc-netty/1.57.0)

This removes CVE-2023-34462 which will address complaints made by FusionReactor customers.

Uses latest netty version as [grpc guys found a regression](https://github.com/grpc/grpc-java/issues/10468) in 4.1.94.Final.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
