### PR TITLE
fix(CFPlugin): fix CF server detection for CF 2023 Windows service

### DIFF
--- a/plugins/cf-plugin/src/main/java/com/intergral/deep/plugin/cf/Utils.java
+++ b/plugins/cf-plugin/src/main/java/com/intergral/deep/plugin/cf/Utils.java
@@ -28,12 +28,22 @@ public final class Utils {
   /**
    * Are we running on a CF server.
    * <p>
-   * By looking at the java start up command we can tell if this is a CF server.
+   * By checking that the coldfusion.home system property exists, or by looking at the java start up command,
+   * we can tell if this is a CF server.
    *
    * @return {@code true} if we are on a coldfusion server.
    */
   public static boolean isCFServer() {
-    return System.getProperty("sun.java.command").contains("coldfusion");
+    if (System.getProperty("coldfusion.home") != null) {
+      return true;
+    }
+
+    final String javaCommand = System.getProperty("sun.java.command");
+    // has the potential to not exist on Windows services
+    if (javaCommand == null) {
+      return false;
+    }
+    return javaCommand.contains("coldfusion");
   }
 
   /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Prevents NullPointerExceptions occurring when the `sun.java.command` system property doesn't exist.

Attempts to find the `coldfusion.home` system property as an additional way to check that Deep is running on a CF server.

**Which issue(s) this PR fixes**:
Fixes #113 

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
