### PR TITLE
fix(CFPlugin): fix CF server detection for CF 2023 Windows service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.2.1 - (12/03/2024)
+- **[BUGFIX]**: plugin: fix ColdFusion detection on Windows [#116](https://github.com/intergral/deep/pull/116) [@LMarkie](https://github.com/LMarkie) 
+
 # 1.2.0 - (06/02/2024)
 - **[CHANGE]**: change log config to allow better control of logging [#103](https://github.com/intergral/deep/pull/103) [@Umaaz](https://github.com/Umaaz)
 - **[CHANGE]**: change tracepoint logger to be a plugin [#106](https://github.com/intergral/deep/pull/106) [@Umaaz](https://github.com/Umaaz)

--- a/plugins/cf-plugin/pom.xml
+++ b/plugins/cf-plugin/pom.xml
@@ -41,6 +41,15 @@
       <version>1.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
+
+    <!-- https://mvnrepository.com/artifact/org.junit-pioneer/junit-pioneer -->
+    <dependency>
+      <groupId>org.junit-pioneer</groupId>
+      <artifactId>junit-pioneer</artifactId>
+      <version>2.2.0</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/plugins/cf-plugin/src/main/java/com/intergral/deep/plugin/cf/Utils.java
+++ b/plugins/cf-plugin/src/main/java/com/intergral/deep/plugin/cf/Utils.java
@@ -28,7 +28,7 @@ public final class Utils {
   /**
    * Are we running on a CF server.
    * <p>
-   * By checking that the coldfusion.home system property exists, or by looking at the java start up command,
+   * By checking that the {@code coldfusion.home} system property exists, or by looking at the java start up command,
    * we can tell if this is a CF server.
    *
    * @return {@code true} if we are on a coldfusion server.

--- a/plugins/cf-plugin/src/main/java/com/intergral/deep/plugin/cf/Utils.java
+++ b/plugins/cf-plugin/src/main/java/com/intergral/deep/plugin/cf/Utils.java
@@ -28,12 +28,22 @@ public final class Utils {
   /**
    * Are we running on a CF server.
    * <p>
-   * By looking at the java start up command we can tell if this is a CF server.
+   * By checking that the coldfusion.home system property exists, or by looking at the java start up command,
+   * we can tell if this is a CF server.
    *
    * @return {@code true} if we are on a coldfusion server.
    */
   public static boolean isCFServer() {
-    return System.getProperty("sun.java.command").contains("coldfusion");
+    if (System.getProperty("coldfusion.home") != null) {
+      return true;
+    }
+
+    final String javaCommand = System.getProperty("sun.java.command");
+    // has the potential to not exist on Windows services
+    if (javaCommand == null) {
+      return false;
+    }
+    return javaCommand.contains("coldfusion");
   }
 
   /**

--- a/plugins/cf-plugin/src/test/java/coldfusion/Version.java
+++ b/plugins/cf-plugin/src/test/java/coldfusion/Version.java
@@ -1,0 +1,27 @@
+/*
+ *     Copyright (C) 2024  Intergral GmbH
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package coldfusion;
+
+public class Version {
+  public static int getMajor() {
+    if (System.getProperty("cf.test.error") != null) {
+      throw new RuntimeException("failed to load version");
+    }
+    return 10;
+  }
+}

--- a/plugins/cf-plugin/src/test/java/com/intergral/deep/plugin/cf/CFPluginTest.java
+++ b/plugins/cf-plugin/src/test/java/com/intergral/deep/plugin/cf/CFPluginTest.java
@@ -1,0 +1,82 @@
+/*
+ *     Copyright (C) 2024  Intergral GmbH
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.intergral.deep.plugin.cf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.intergral.deep.agent.api.plugin.EvaluationException;
+import com.intergral.deep.agent.api.plugin.ISnapshotContext;
+import com.intergral.deep.agent.api.resource.Resource;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class CFPluginTest {
+
+  @Test
+  void canDecorate() throws EvaluationException {
+    final CFPlugin cfPlugin = new CFPlugin();
+    final ISnapshotContext mock = Mockito.mock(ISnapshotContext.class);
+
+    final Resource decorate = cfPlugin.decorate(null, mock);
+    assertNotNull(decorate);
+    assertEquals("10", decorate.getAttributes().get("cf_version"));
+    assertNull(decorate.getAttributes().get("app_name"));
+
+    Mockito.verify(mock).evaluateExpression("APPLICATION.applicationname");
+  }
+
+  @Test
+  void canHandleEvaluateDecorate() throws EvaluationException {
+    final CFPlugin cfPlugin = new CFPlugin();
+
+    final ISnapshotContext mock = Mockito.mock(ISnapshotContext.class);
+
+    Mockito.when(mock.evaluateExpression("APPLICATION.applicationname")).thenReturn("app_name");
+
+    final Resource decorate = cfPlugin.decorate(null, mock);
+    assertNotNull(decorate);
+    assertEquals("10", decorate.getAttributes().get("cf_version"));
+    assertEquals("app_name", decorate.getAttributes().get("app_name"));
+
+    Mockito.verify(mock).evaluateExpression("APPLICATION.applicationname");
+  }
+
+  @Test
+  void canHandleEvaluateFailedDecorate() throws EvaluationException {
+    final CFPlugin cfPlugin = new CFPlugin();
+
+    final ISnapshotContext mock = Mockito.mock(ISnapshotContext.class);
+
+    Mockito.when(mock.evaluateExpression("APPLICATION.applicationname")).thenThrow(new RuntimeException("test exception"));
+
+    final Resource decorate = cfPlugin.decorate(null, mock);
+    assertNotNull(decorate);
+    assertEquals("10", decorate.getAttributes().get("cf_version"));
+    assertNull(decorate.getAttributes().get("app_name"));
+
+    Mockito.verify(mock).evaluateExpression("APPLICATION.applicationname");
+  }
+
+  @Test
+  void isActive() {
+    assertFalse(new CFPlugin().isActive());
+  }
+}

--- a/plugins/cf-plugin/src/test/java/com/intergral/deep/plugin/cf/UtilsTest.java
+++ b/plugins/cf-plugin/src/test/java/com/intergral/deep/plugin/cf/UtilsTest.java
@@ -32,6 +32,7 @@ class UtilsTest {
   void canDetectNotCF() {
     assertFalse(Utils.isCFServer());
   }
+
   @Test
   @ClearSystemProperty(key = "sun.java.command")
   void canHandleNoSunCommand() {
@@ -39,13 +40,13 @@ class UtilsTest {
   }
 
   @Test
-  @SetSystemProperty(key = "coldfusion.home", value ="doesn't matter")
+  @SetSystemProperty(key = "coldfusion.home", value = "doesn't matter")
   void canDetectCFHome() {
     assertTrue(Utils.isCFServer());
   }
 
   @Test
-  @SetSystemProperty(key = "sun.java.command", value ="/some/coldfusion")
+  @SetSystemProperty(key = "sun.java.command", value = "/some/coldfusion")
   void canUseSunCommand() {
     assertTrue(Utils.isCFServer());
   }
@@ -56,7 +57,7 @@ class UtilsTest {
   }
 
   @Test
-  @SetSystemProperty(key="cf.test.error", value = "anything")
+  @SetSystemProperty(key = "cf.test.error", value = "anything")
   void failLoadCFVersion() {
     assertNull(Utils.loadCFVersion());
   }

--- a/plugins/cf-plugin/src/test/java/com/intergral/deep/plugin/cf/UtilsTest.java
+++ b/plugins/cf-plugin/src/test/java/com/intergral/deep/plugin/cf/UtilsTest.java
@@ -1,0 +1,63 @@
+/*
+ *     Copyright (C) 2024  Intergral GmbH
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.intergral.deep.plugin.cf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ClearSystemProperty;
+import org.junitpioneer.jupiter.SetSystemProperty;
+
+class UtilsTest {
+
+  @Test
+  void canDetectNotCF() {
+    assertFalse(Utils.isCFServer());
+  }
+  @Test
+  @ClearSystemProperty(key = "sun.java.command")
+  void canHandleNoSunCommand() {
+    assertFalse(Utils.isCFServer());
+  }
+
+  @Test
+  @SetSystemProperty(key = "coldfusion.home", value ="doesn't matter")
+  void canDetectCFHome() {
+    assertTrue(Utils.isCFServer());
+  }
+
+  @Test
+  @SetSystemProperty(key = "sun.java.command", value ="/some/coldfusion")
+  void canUseSunCommand() {
+    assertTrue(Utils.isCFServer());
+  }
+
+  @Test
+  void loadCFVersion() {
+    assertEquals("10", Utils.loadCFVersion());
+  }
+
+  @Test
+  @SetSystemProperty(key="cf.test.error", value = "anything")
+  void failLoadCFVersion() {
+    assertNull(Utils.loadCFVersion());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -553,7 +553,8 @@
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter</artifactId>
-                <version>5.10.1</version>
+                <!-- Version upgrade blocked by junit-pioneer version -->
+                <version>5.9.3</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Prevents NullPointerExceptions occurring when the `sun.java.command` system property doesn't exist.

Attempts to find the `coldfusion.home` system property as an additional way to check that Deep is running on a CF server.

**Which issue(s) this PR fixes**:
Fixes #113 

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
