### PR TITLE
Update netty to 4.1.118.Final and move to v4 artifact actions

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -24,7 +24,7 @@ jobs:
         run: make coverage
 
       - name: Test Reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Test Reports

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -30,7 +30,7 @@ jobs:
       - run: pip install mkdocs-material
       - run: mkdocs build -d./_site
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Mk docs
           path: _site
@@ -41,7 +41,7 @@ jobs:
       - mkdocs
     steps:
       - name: Download Mkdocs artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Mk docs
           path: _site

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <properties>
         <deep-proto.version>1.0.5</deep-proto.version>
         <grpc.version>1.66.0</grpc.version>
-        <netty.version>4.1.115.Final</netty.version>
+        <netty.version>4.1.118.Final</netty.version>
         <tcnative.version>2.0.65.Final</tcnative.version>
         <asm.version>8.0.1</asm.version>
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Updates the netty dependency, removing the `CVE-2025-25193` and `CVE-2025-24970` vulnerabilities even though they may not affect this project.

Moved from the [deprecated v3 artifact actions](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) to their supported v4 equivalent.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
